### PR TITLE
Change login password to a Base64 encoded string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setuptools.setup(
     package_dir={"": "src"},
     packages=setuptools.find_packages(where="src"),
     python_requires=">=3.6",
-    install_requires=['requests']
+    install_requires=['requests', 'hashlib', 'base64']
 )

--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -1,4 +1,6 @@
 import requests
+import hashlib
+import base64
 
 class irDataClient:
     def __init__(self, username=None, password=None):
@@ -15,10 +17,14 @@ class irDataClient:
     def _login(self, username=None, password=None):
         if not username or not password:
             raise RuntimeError("Please supply a username and password")
-        
+
+        # iRacing requires Base64 encoded string as of 2022 season 3
+        password_hash = hashlib.sha256((password + username.lower()).encode('utf-8')).digest()
+        password_b64 = base64.b64encode(password_hash).decode('utf-8')
+
         payload = {
             "email": username,
-            "password": password
+            "password": password_b64
         }
 
         r = self.session.post(self._build_url("/auth"), json=payload)


### PR DESCRIPTION
Fixes #1 

iRacing made breaking changes in 2022 season 3 that now requires a base64 encoded string to be sent as the password in the login payload. More info in https://forums.iracing.com/discussion/22109/login-form-changes/p1

Tested by executing examples in the readme. 