### PR TITLE
Adding the search_series method, modifying _get_resource_link

### DIFF
--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -38,7 +38,7 @@ class irDataClient:
     def _build_url(self, endpoint):
         return self.base_url + endpoint
 
-    def _get_resource_link(self, url, payload=None):
+    def _get_resource_or_link(self, url, payload=None):
         r = self.session.get(url, params=payload)
         if r.status_code != 200:
             raise RuntimeError(r.json())
@@ -50,10 +50,10 @@ class irDataClient:
 
     def _get_resource(self, endpoint, payload=None):
         request_url = self._build_url(endpoint)
-        resource_link = self._get_resource_link(request_url, payload=payload)
-        if not resource_link[1]:
-            return resource_link[0]
-        r = self.session.get(resource_link[0])
+        resource_obj, is_link = self._get_resource_or_link(request_url, payload=payload)
+        if not is_link:
+            return resource_obj
+        r = self.session.get(resource_obj)
         if r.status_code != 200:
             raise RuntimeError(r.json())
         return r.json()


### PR DESCRIPTION
The issue I was running into initially adding the `search_series` function was that the `_get_resource_link` function was calling the endpoint, but the response was not providing a.. well.. resource link. It was providing a different response that I believe is similar to what we expect as the response from the resource link itself (i.e. what we use to access and interpret the chunks in the `_get_chunks` function). 

My solution was to check to see if the link existed as a key in the response json, and return the response + the boolean indicating if the 0 index was a resource link or not. Then in `_get_resource` we just check to see if what we have is a resource link or not. If it is _not_ a resource link, we just return the resulting json object. If it is, we proceed as expected previously.

Onto the actual function that I added, I followed the blueprint provided by the `result_search_hosted` function. 

My concern is that now the `_get_resource_link` function does not always return a resource link, so the name is a bit misleading. I think there's a more elegant way to try-catch this or something but this was the first thing I thought of, it worked, and I figured if it ain't broke don't fix it.

Thanks for coming to my TED talk.