### PR TITLE
Endpoint `/season/list` added.

### DIFF
--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -430,6 +430,10 @@ class irDataClient:
         payload = {"team_id": team_id, "include_licenses": include_licenses}
         return self._get_resource("/data/team/get", payload=payload)
 
+    def season_list(self, season_year, season_quarter):
+        payload = {"season_year": season_year, "season_quarter": season_quarter}
+        return self._get_resource("/data/season/list", payload=payload)
+    
     def series(self):
         return self._get_resource("/data/series/get")
 


### PR DESCRIPTION
Similar to #9, Missing endpoint `/season/list` was added. 

This endpoint was recently mentioned by Nicholas in the official forum thread:

> A new endpoint has been deployed which should allow you to do what you want. This endpoint will allow you to lookup the series that existed during a given season year & quarter.