### PR TITLE
Fixed check for positive delta

### DIFF
--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -64,7 +64,7 @@ class irDataClient:
             print("Rate limited, waiting")
             reset_datetime = datetime.fromtimestamp(int(r.headers["x-ratelimit-reset"]))
             delta = reset_datetime - datetime.now()
-            if delta > 0:
+            if delta.total_seconds() > 0:
                 time.sleep(delta.total_seconds())
             return self._get_resource_or_link(url, payload=payload)
 
@@ -429,7 +429,7 @@ class irDataClient:
     def stats_member_yearly(self, cust_id=None):
         if not cust_id:
             raise RuntimeError("Please supply a cust_id")
-
+        
         payload = {"cust_id": cust_id}
         return self._get_resource("/data/stats/member_yearly", payload=payload)
 

--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -434,7 +434,6 @@ class irDataClient:
     def stats_member_yearly(self, cust_id=None):
         if not cust_id:
             raise RuntimeError("Please supply a cust_id")
-        
         payload = {"cust_id": cust_id}
         return self._get_resource("/data/stats/member_yearly", payload=payload)
 

--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -64,10 +64,10 @@ class irDataClient:
             print("Rate limited, waiting")
             ratelimit_reset = r.headers.get("x-ratelimit-reset")
             if ratelimit_reset:
-            	reset_datetime = datetime.fromtimestamp(int(ratelimit_reset))
-				delta = reset_datetime - datetime.now()
-				if delta.total_seconds() > 0:
-					time.sleep(delta.total_seconds())
+                reset_datetime = datetime.fromtimestamp(int(ratelimit_reset))
+                delta = reset_datetime - datetime.now()
+                if delta.total_seconds() > 0:
+                    time.sleep(delta.total_seconds())
             return self._get_resource_or_link(url, payload=payload)
 
         if r.status_code != 200:


### PR DESCRIPTION
There was a small issue with the rate limit: The check for a positive delta compared a `timedelta` with an `int`, I added `.total_seconds()` to fix this.

This should do the trick, but I haven't found a way to reliably trigger the rate limiting, so I couldn't test this...