### PR TITLE
Fixed `_get_chunks`

### DIFF
--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -87,8 +87,11 @@ class irDataClient:
         return r.json()
 
     def _get_chunks(self, chunks):
-        base_url = chunks["base_download_url"]
-        urls = [base_url + x for x in chunks["chunk_file_names"]]
+        if not isinstance(chunks, dict):
+            # if there are no chunks, return an empty list for compatibility
+            return []
+        base_url = chunks.get("base_download_url")
+        urls = [base_url + x for x in chunks.get("chunk_file_names")]
         list_of_chunks = [self.session.get(url).json() for url in urls]
         output = [item for sublist in list_of_chunks for item in sublist]
 


### PR DESCRIPTION
**First commit**
I recently discovered that `_get_chunks` raises an error, if an empty response is received. (e.g. there are no world record for a car-&-track combo)
By checking if the `chunks` argument is a dict or not, and returning an empty list if it is not, that small oversight should be fixed.

**Second commit**
While doing the first commit I noticed how values are being recalled from dicts and that there is some room for improvement.
Imo `x = dict.get("key")` should be used, since it prevents a KeyError, if `"key"` is not valid and returns `None` instead. (Or whatever is provided as an optional second argument after the key).
I changed all occurence of `x = dict["key"]` to the better suited solution. To accommodate this, I had to do some minor adjustments, as well.