### PR TITLE
Results search series. Add finish_range_begin to attributes validation.

### DIFF
--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -712,7 +712,7 @@ class irDataClient:
             list: a list containing all the hosted results matching criteria.
 
         """
-        if not ((season_year and season_quarter) or (start_range_begin)):
+        if not ((season_year and season_quarter) or start_range_begin or finish_range_begin):
             raise RuntimeError(
                 "Please supply Season Year and Season Quarter or a date range"
             )
@@ -1135,7 +1135,7 @@ class irDataClient:
 
     def season_spectator_subsessionids(self, event_types:list=[2,3,4,5]):
         """Get the current list of subsession IDs for a given event type
-        
+
         Args:
             event_types (list): A list of integers that match with iRacing event types as follows:
                 2: Practise
@@ -1149,7 +1149,7 @@ class irDataClient:
         payload = {}
         if event_types:
             payload["event_types": ",".join(event_types)]
-        
+
         return self._get_resource("/data/season/spectator_subsessionids", payload=payload)
 
     def get_series(self):


### PR DESCRIPTION
According to the api doc results/search_series endpoint requires at least one of: season_year and season_quarter, start_range_begin, finish_range_begin.