### PR TITLE
Added missing endpoints and minor clean-up.

### DIFF
--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -400,6 +400,21 @@ class irDataClient:
         payload = {"include_league": include_league}
         return self._get_resource("/data/league/membership", payload=payload)
 
+    def league_roster(self, league_id, include_licenses=False):
+        """
+        Args:
+            league_id (int): the league to retrieve the roster
+            include_licenses (bool): if ``True``, also receives license information.
+                                    For faster responses, only request when necessary.
+
+        Returns:
+            dict: A dict containing information about the league roster
+        """
+        payload = {"league_id": league_id}
+        if include_licenses:
+            payload["include_licenses"] = include_licenses
+        return self._get_resource("/data/league/roster", payload=payload)
+
     def league_seasons(self, league_id, retired=False):
         """Fetches a list containing all the seasons from a league.
 

--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -906,10 +906,9 @@ class irDataClient:
             dict: a dict containing the member career stats
 
         """
-        if not cust_id:
-            raise RuntimeError("Please supply a cust_id")
-
-        payload = {"cust_id": cust_id}
+        payload = {}
+        if cust_id:
+            payload["cust_id"] = cust_id
         return self._get_resource("/data/stats/member_career", payload=payload)
 
     def stats_member_recap(self, cust_id=None, year=None, quarter=None):

--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -920,7 +920,7 @@ class irDataClient:
         payload = {"cust_id": cust_id}
         return self._get_resource("/data/stats/member_career", payload=payload)
 
-    def stats_member_division(self, season_id=None, event_type=None):
+    def stats_member_division(self, season_id, event_type):
         """Get the member division for a season and event type.
 
         Divisions are 0-based: 0 is Division 1, 10 is Rookie. Always for the authenticated member.
@@ -932,10 +932,6 @@ class irDataClient:
         Returns:
             dict: a dict containing the division the member is in for the requested season.
         """
-
-        if not season_id and event_type:
-            raise RuntimeError("Please supply both a season_id and an event_type")
-
         payload = {"season_id": season_id, "event_type": event_type}
         return self._get_resource("/data/stats/member_division", payload=payload)
 
@@ -1297,7 +1293,7 @@ class irDataClient:
         )
         return self.get_series_assets()
 
-    def series_past_seasons(self, series_id=None):
+    def series_past_seasons(self, series_id):
         """Get all seasons for a series.
 
         Filter list by ``'official'``: ``True`` for seasons with standings.
@@ -1308,9 +1304,6 @@ class irDataClient:
         Returns:
             dict: a dict containing information about the series and a list of seasons.
         """
-        if not series_id:
-            raise RuntimeError("Please supply a series_id")
-
         payload = {"series_id": series_id}
         return self._get_resource("/data/series/past_seasons", payload=payload)
 

--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -888,7 +888,7 @@ class irDataClient:
         """Get the member best laptimes from a certain cust_id and car_id.
 
         Args:
-            cust_id (int): The iRacing cust_id. Default the authenticated member.
+            cust_id (int): The iRacing cust_id. Defaults to the authenticated member.
             car_id (int): The car id. First call should exclude car_id;
              use cars_driven list in return for subsequent calls.
 
@@ -908,7 +908,7 @@ class irDataClient:
         """Get the member career stats from a certain cust_id
 
         Args:
-            cust_id (int): The iRacing cust_id. Default the authenticated member.
+            cust_id (int): The iRacing cust_id. Defaults to the authenticated member.
 
         Returns:
             dict: a dict containing the member career stats
@@ -919,6 +919,25 @@ class irDataClient:
 
         payload = {"cust_id": cust_id}
         return self._get_resource("/data/stats/member_career", payload=payload)
+
+    def stats_member_division(self, season_id=None, event_type=None):
+        """Get the member division for a season and event type.
+
+        Divisions are 0-based: 0 is Division 1, 10 is Rookie. Always for the authenticated member.
+
+        Args:
+            season_id (int): The ID for the season being requested.
+            event_type (int): The event type code for the division type: 4 - Time Trial; 5 - Race
+
+        Returns:
+            dict: a dict containing the division the member is in for the requested season.
+        """
+
+        if not season_id and event_type:
+            raise RuntimeError("Please supply both a season_id and an event_type")
+
+        payload = {"season_id": season_id, "event_type": event_type}
+        return self._get_resource("/data/stats/member_division", payload=payload)
 
     def stats_member_recent_races(self, cust_id=None):
         """Get the latest member races from a certain cust_id
@@ -1258,7 +1277,7 @@ class irDataClient:
         )
         return self.get_series_assets()
 
-    def series_past_seasons(self, series_id):
+    def series_past_seasons(self, series_id=None):
         """Get all seasons for a series.
 
         Filter list by ``'official'``: ``True`` for seasons with standings.

--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -861,6 +861,14 @@ class irDataClient:
         """
         return self._get_resource("/data/member/info")
 
+    def member_participation_credits(self):
+        """Participation credit info from the authenticated member.
+
+        Returns:
+            list: a list of dicts containing participation credit information.
+        """
+        return self._get_resource("/data/member/participation_credits")
+
     def member_profile(self, cust_id=None):
         """Detailed profile info from a member.
 

--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -965,10 +965,10 @@ class irDataClient:
             dict: a dict containing the latest member races
 
         """
-        if not cust_id:
-            raise RuntimeError("Please supply a cust_id")
+        payload = {}
+        if cust_id:
+            payload = {"cust_id": cust_id}
 
-        payload = {"cust_id": cust_id}
         return self._get_resource("/data/stats/member_recent_races", payload=payload)
 
     def stats_member_summary(self, cust_id=None):
@@ -981,10 +981,10 @@ class irDataClient:
             dict: a dict containing the member stats summary
 
         """
-        if not cust_id:
-            raise RuntimeError("Please supply a cust_id")
+        payload = {}
+        if cust_id:
+            payload = {"cust_id": cust_id}
 
-        payload = {"cust_id": cust_id}
         return self._get_resource("/data/stats/member_summary", payload=payload)
 
     def stats_member_yearly(self, cust_id=None):
@@ -997,9 +997,10 @@ class irDataClient:
             dict: a dict containing the member stats yearly
 
         """
-        if not cust_id:
-            raise RuntimeError("Please supply a cust_id")
-        payload = {"cust_id": cust_id}
+        payload = {}
+        if cust_id:
+            payload = {"cust_id": cust_id}
+
         return self._get_resource("/data/stats/member_yearly", payload=payload)
 
     def stats_season_driver_standings(

--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -939,6 +939,26 @@ class irDataClient:
         payload = {"season_id": season_id, "event_type": event_type}
         return self._get_resource("/data/stats/member_division", payload=payload)
 
+    def stats_member_recap(self, cust_id=None, year=None, quarter=None):
+        """Get a recap for the member.
+
+        Args:
+            cust_id (int): The iRacing cust_id. Default the authenticated member.
+            year (int): Season year; if not supplied the current calendar year (UTC) is used.
+            quarter (int): Season (quarter) within the year; if not supplied the recap will be fore the entire year.
+
+        Returns:
+            dict: a dict containing a recap from the requested season/quarter/member
+        """
+        payload = {}
+        if cust_id:
+            payload["cust_id"] = cust_id
+        if year:
+            payload["year"] = year
+        if quarter:
+            payload["season"] = quarter
+        return self._get_resource("/data/stats/member_recap", payload=payload)
+
     def stats_member_recent_races(self, cust_id=None):
         """Get the latest member races from a certain cust_id
 

--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -861,14 +861,6 @@ class irDataClient:
         """
         return self._get_resource("/data/member/info")
 
-    def member_participation_credits(self):
-        """Participation credit info from the authenticated member.
-
-        Returns:
-            list: a list of dicts containing participation credit information.
-        """
-        return self._get_resource("/data/member/participation_credits")
-
     def member_profile(self, cust_id=None):
         """Detailed profile info from a member.
 
@@ -920,26 +912,11 @@ class irDataClient:
         payload = {"cust_id": cust_id}
         return self._get_resource("/data/stats/member_career", payload=payload)
 
-    def stats_member_division(self, season_id, event_type):
-        """Get the member division for a season and event type.
-
-        Divisions are 0-based: 0 is Division 1, 10 is Rookie. Always for the authenticated member.
-
-        Args:
-            season_id (int): The ID for the season being requested.
-            event_type (int): The event type code for the division type: 4 - Time Trial; 5 - Race
-
-        Returns:
-            dict: a dict containing the division the member is in for the requested season.
-        """
-        payload = {"season_id": season_id, "event_type": event_type}
-        return self._get_resource("/data/stats/member_division", payload=payload)
-
     def stats_member_recap(self, cust_id=None, year=None, quarter=None):
         """Get a recap for the member.
 
         Args:
-            cust_id (int): The iRacing cust_id. Default the authenticated member.
+            cust_id (int): The iRacing cust_id. Defaults  to the authenticated member.
             year (int): Season year; if not supplied the current calendar year (UTC) is used.
             quarter (int): Season (quarter) within the year; if not supplied the recap will be fore the entire year.
 
@@ -959,7 +936,7 @@ class irDataClient:
         """Get the latest member races from a certain cust_id
 
         Args:
-            cust_id (int): The iRacing cust_id. Default the authenticated member.
+            cust_id (int): The iRacing cust_id. Defaults to the authenticated member.
 
         Returns:
             dict: a dict containing the latest member races
@@ -975,7 +952,7 @@ class irDataClient:
         """Get the member stats summary from a certain cust_id
 
         Args:
-            cust_id (int): The iRacing cust_id. Default the authenticated member.
+            cust_id (int): The iRacing cust_id. Defaults to the authenticated member.
 
         Returns:
             dict: a dict containing the member stats summary
@@ -991,7 +968,7 @@ class irDataClient:
         """Get the member stats yearly from a certain cust_id
 
         Args:
-            cust_id (int): The iRacing cust_id. Default the authenticated member.
+            cust_id (int): The iRacing cust_id. Defaults to the authenticated member.
 
         Returns:
             dict: a dict containing the member stats yearly
@@ -1211,20 +1188,6 @@ class irDataClient:
         """
         payload = {"team_id": team_id, "include_licenses": include_licenses}
         return self._get_resource("/data/team/get", payload=payload)
-
-    def time_attack_member_season_results(self, ta_comp_season_id):
-        """Get the member time attack results for a competition season.
-
-        Results for the authenticated member, if any.
-
-        Args:
-            ta_comp_season_id (int): Time Attack Competition Season ID
-
-        Returns:
-            list: a list of results, if any.
-        """
-        payload = {"ta_comp_season_id": ta_comp_season_id}
-        return self._get_resource("/data/time_attack/member_season_results", payload=payload)
 
     def season_list(self, season_year, season_quarter):
         """Get the list of iRacing Official seasons given a year and quarter.

--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -1012,8 +1012,9 @@ class irDataClient:
             season_id (int): The iRacing season id.
             car_class_id (int): the iRacing car class id.
             race_week_num (int): the race week number (0-12). Default 0.
-            club_id (int): the iRacing club id.
-            division (int): the iRacing division.
+            club_id (int): the iRacing club id. Defaults to all (-1).
+            division (int): the iRacing division. Divisions are 0-based: 0 is Division 1, 10 is Rookie.
+                            See /data/constants/divisons for more information. Defaults to all.
 
         Returns:
             dict: a dict containing the season driver standings
@@ -1041,8 +1042,9 @@ class irDataClient:
             season_id (int): The iRacing season id.
             car_class_id (int): the iRacing car class id.
             race_week_num (int): the race week number (0-12). Default 0.
-            club_id (int): the iRacing club id.
-            division (int): the iRacing division.
+            club_id (int): the iRacing club id. Defaults to all (-1).
+            division (int): the iRacing division. Divisions are 0-based: 0 is Division 1, 10 is Rookie.
+                            See /data/constants/divisons for more information. Defaults to all.
 
         Returns:
             dict: a dict containing the season supersession standings
@@ -1209,6 +1211,20 @@ class irDataClient:
         """
         payload = {"team_id": team_id, "include_licenses": include_licenses}
         return self._get_resource("/data/team/get", payload=payload)
+
+    def time_attack_member_season_results(self, ta_comp_season_id):
+        """Get the member time attack results for a competition season.
+
+        Results for the authenticated member, if any.
+
+        Args:
+            ta_comp_season_id (int): Time Attack Competition Season ID
+
+        Returns:
+            list: a list of results, if any.
+        """
+        payload = {"ta_comp_season_id": ta_comp_season_id}
+        return self._get_resource("/data/time_attack/member_season_results", payload=payload)
 
     def season_list(self, season_year, season_quarter):
         """Get the list of iRacing Official seasons given a year and quarter.

--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -54,15 +54,6 @@ class irDataClient:
             else:
                 raise RuntimeError("Error from iRacing: ", response_data)
 
-
-
-
-
-
-
-
-
-
     def _build_url(self, endpoint):
         return self.base_url + endpoint
 
@@ -190,7 +181,7 @@ class irDataClient:
         Qualify, Time Trial or Race)
 
         Returns:
-            A list of dicts representing each event type.
+            list: A list of dicts representing each event type.
 
         """
         return self._get_resource("/data/constants/event_types")
@@ -449,23 +440,6 @@ class irDataClient:
             payload["car_id"] = car_id
 
         return self._get_resource("/data/league/season_standings", payload=payload)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
     def league_season_sessions(self, league_id, season_id, results_only=False):
         """Fetches a dict containing all the sessions from a league session.

--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -408,12 +408,18 @@ class irDataClient:
              For faster responses, only request when necessary.
 
         Returns:
-            dict: A dict containing information about the league roster
+            dict: A dict containing the league roster.
         """
         payload = {"league_id": league_id}
         if include_licenses:
             payload["include_licenses"] = include_licenses
-        return self._get_resource("/data/league/roster", payload=payload)
+
+        resource = self._get_resource("/data/league/roster", payload=payload)
+
+        if resource.get('data', {}).get('success'):
+            return self._get_resource_or_link(resource['data_url'])[0]
+        else:
+            return {}
 
     def league_seasons(self, league_id, retired=False):
         """Fetches a list containing all the seasons from a league.
@@ -815,12 +821,18 @@ class irDataClient:
             cust_id (int): the iRacing cust_id. Defaults to the authenticated member.
 
         Returns:
-            dict: A dict containing information about the members awards.
+            list: A list of dicts containing all the members awards.  On failure, returns an empty list.
         """
         payload = {}
         if cust_id:
             payload["cust_id"] = cust_id
-        return self._get_resource("/data/member/awards", payload=payload)
+
+        resource = self._get_resource("/data/member/awards", payload=payload)
+
+        if resource.get('data', {}).get('success'):
+            return self._get_resource_or_link(resource['data_url'])[0]
+        else:
+            return []
 
     def member_chart_data(self, cust_id=None, category_id=2, chart_type=1):
         """Get the irating, ttrating or safety rating chart data of a certain category.
@@ -1232,7 +1244,8 @@ class irDataClient:
 
     def series_assets(self):
         print(
-            "series_assets() is deprecated and will be removed in a future release, please update to use get_series_assets"
+            "series_assets() is deprecated and will be removed in a future release, "
+            "please update to use get_series_assets"
         )
         return self.get_series_assets()
 

--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -1,7 +1,7 @@
 import base64
 import hashlib
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import requests
 

--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -54,6 +54,15 @@ class irDataClient:
             else:
                 raise RuntimeError("Error from iRacing: ", response_data)
 
+
+
+
+
+
+
+
+
+
     def _build_url(self, endpoint):
         return self.base_url + endpoint
 
@@ -441,6 +450,23 @@ class irDataClient:
 
         return self._get_resource("/data/league/season_standings", payload=payload)
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def league_season_sessions(self, league_id, season_id, results_only=False):
         """Fetches a dict containing all the sessions from a league session.
 
@@ -763,7 +789,7 @@ class irDataClient:
             race_week_num (int): The first race week of a season is 0.
 
         Returns:
-            list: a list of sessions within the matching criteria.
+            dict: a dict containing a list of sessions within the matching criteria.
 
         """
         payload = {"season_id": season_id}

--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -873,7 +873,7 @@ class irDataClient:
         """Detailed profile info from a member.
 
         Args:
-            cust_id (int): The iRacing cust_id. Default the authenticated member.
+            cust_id (int): The iRacing cust_id. Defaults to the authenticated member.
 
         Returns:
             dict: a dict containing the detailed profile info from the member requested.
@@ -1243,6 +1243,7 @@ class irDataClient:
         """Get all the current official iRacing series assets.
 
         Get the images, description and logos from the current official iRacing series.
+        Image paths are relative to https://images-static.iracing.com/
 
         Returns:
             dict: a dict containing all the current official iRacing series assets.
@@ -1256,6 +1257,23 @@ class irDataClient:
             "please update to use get_series_assets"
         )
         return self.get_series_assets()
+
+    def series_past_seasons(self, series_id):
+        """Get all seasons for a series.
+
+        Filter list by ``'official'``: ``True`` for seasons with standings.
+
+        Args:
+            series_id ():
+
+        Returns:
+            dict: a dict containing information about the series and a list of seasons.
+        """
+        if not series_id:
+            raise RuntimeError("Please supply a series_id")
+
+        payload = {"series_id": series_id}
+        return self._get_resource("/data/series/past_seasons", payload=payload)
 
     def series_seasons(self, include_series=False):
         """Get the all the seasons.

--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -1322,7 +1322,7 @@ class irDataClient:
             dict: a dict containing information about the series and a list of seasons.
         """
         payload = {"series_id": series_id}
-        return self._get_resource("/data/series/past_seasons", payload=payload)
+        return self._get_resource("/data/series/past_seasons", payload=payload).get('series')
 
     def series_seasons(self, include_series=False):
         """Get the all the seasons.

--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -405,7 +405,7 @@ class irDataClient:
         Args:
             league_id (int): the league to retrieve the roster
             include_licenses (bool): if ``True``, also receives license information.
-                                    For faster responses, only request when necessary.
+             For faster responses, only request when necessary.
 
         Returns:
             dict: A dict containing information about the league roster
@@ -813,8 +813,8 @@ class irDataClient:
         """Get the irating, ttrating or safety rating chart data of a certain category.
 
         Args:
-            cust_id (int): the iRacing cust_id
-            category_id (int): 1 - Oval; 2 - Road; 3 - Dirt oval; 4 - Dirt road
+            cust_id (int): the iRacing cust_id. Defaults to the authenticated member.
+            category_id (int): 1 - Oval; 2 - Road; 3 - Dirt oval; 4 - Dirt road; 5 - Sports Car; 6 - Formula Car
             chart_type (int): 1 - iRating; 2 - TT Rating; 3 - License/SR
 
         Returns:

--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -416,10 +416,7 @@ class irDataClient:
 
         resource = self._get_resource("/data/league/roster", payload=payload)
 
-        if resource.get('data', {}).get('success'):
-            return self._get_resource_or_link(resource['data_url'])[0]
-        else:
-            return {}
+        return self._get_resource_or_link(resource['data_url'])[0]
 
     def league_seasons(self, league_id, retired=False):
         """Fetches a list containing all the seasons from a league.
@@ -829,10 +826,7 @@ class irDataClient:
 
         resource = self._get_resource("/data/member/awards", payload=payload)
 
-        if resource.get('data', {}).get('success'):
-            return self._get_resource_or_link(resource['data_url'])[0]
-        else:
-            return []
+        return self._get_resource_or_link(resource['data_url'])[0]
 
     def member_chart_data(self, cust_id=None, category_id=2, chart_type=1):
         """Get the irating, ttrating or safety rating chart data of a certain category.

--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -401,7 +401,7 @@ class irDataClient:
         return self._get_resource("/data/league/membership", payload=payload)
 
     def league_roster(self, league_id, include_licenses=False):
-        """
+        """Fetches a dict containing information about the league roster.
         Args:
             league_id (int): the league to retrieve the roster
             include_licenses (bool): if ``True``, also receives license information.
@@ -808,6 +808,19 @@ class irDataClient:
 
         payload = {"cust_ids": cust_id, "include_licenses": include_licenses}
         return self._get_resource("/data/member/get", payload=payload)
+
+    def member_awards(self, cust_id=None):
+        """Fetches a dict containing information on the members awards.
+        Args:
+            cust_id (int): the iRacing cust_id. Defaults to the authenticated member.
+
+        Returns:
+            dict: A dict containing information about the members awards.
+        """
+        payload = {}
+        if cust_id:
+            payload["cust_id"] = cust_id
+        return self._get_resource("/data/member/awards", payload=payload)
 
     def member_chart_data(self, cust_id=None, category_id=2, chart_type=1):
         """Get the irating, ttrating or safety rating chart data of a certain category.


### PR DESCRIPTION

Added the following endpoints:
- /time_attack/member_season_results
- /stats/member_recap
- /stats/member_division
- /series/past_seasons
- /member/participation_credits
- /member/awards
- /league/roster

Removed the check to ensure a cust_id was passed to the following methods because they all are supposed to default to the authenticated user and the cust_id is not required.
- `stats_member_summary()`
- `stats_member_yearly()`
- `stats_member_recent_races()`

There were other minor updates, including revising the incorrectly documented return type in `league_season_sessions()` to eliminate issues with inferred return types when using the library.