### PR TITLE
corrected check on default values of None

### DIFF
--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -855,7 +855,7 @@ class irDataClient:
         payload = {"season_id": season_id}
         if event_type:
             payload["event_type"] = event_type
-        if race_week_num:
+        if race_week_num is not None:
             payload["race_week_num"] = race_week_num
 
         return self._get_resource("/data/results/season_results", payload=payload)
@@ -1067,11 +1067,11 @@ class irDataClient:
 
         """
         payload = {"season_id": season_id, "car_class_id": car_class_id}
-        if race_week_num:
+        if race_week_num is not None:
             payload["race_week_num"] = race_week_num
         if club_id:
             payload["club_id"] = club_id
-        if division:
+        if division is not None:
             payload["division"] = division
 
         resource = self._get_resource(
@@ -1102,11 +1102,11 @@ class irDataClient:
 
         """
         payload = {"season_id": season_id, "car_class_id": car_class_id}
-        if race_week_num:
+        if race_week_num is not None:
             payload["race_week_num"] = race_week_num
         if club_id:
             payload["club_id"] = club_id
-        if division:
+        if division is not None:
             payload["division"] = division
 
         resource = self._get_resource(
@@ -1122,14 +1122,14 @@ class irDataClient:
         Args:
             season_id (int): The iRacing season id.
             car_class_id (int): the iRacing car class id.
-            race_week_num (int): the race week number (0-12). Default 0.
+            race_week_num (int): the race week number (0-12).
 
         Returns:
             dict: a dict containing the season team standings
 
         """
         payload = {"season_id": season_id, "car_class_id": car_class_id}
-        if race_week_num:
+        if race_week_num is not None:
             payload["race_week_num"] = race_week_num
 
         resource = self._get_resource(
@@ -1150,7 +1150,7 @@ class irDataClient:
         Args:
             season_id (int): The iRacing season id.
             car_class_id (int): the iRacing car class id.
-            race_week_num (int): the race week number (0-12). Default 0.
+            race_week_num (int): the race week number (0-12).
             club_id (int): the iRacing club id.
             division (int): the iRacing division.
 
@@ -1159,11 +1159,11 @@ class irDataClient:
 
         """
         payload = {"season_id": season_id, "car_class_id": car_class_id}
-        if race_week_num:
+        if race_week_num is not None:
             payload["race_week_num"] = race_week_num
         if club_id:
             payload["club_id"] = club_id
-        if division:
+        if division is not None:
             payload["division"] = division
 
         resource = self._get_resource(
@@ -1184,7 +1184,7 @@ class irDataClient:
         Args:
             season_id (int): The iRacing season id.
             car_class_id (int): the iRacing car class id.
-            race_week_num (int): the race week number (0-12). Default 0.
+            race_week_num (int): the race week number (0-12).
             club_id (int): the iRacing club id.
             division (int): the iRacing division.
 
@@ -1199,7 +1199,7 @@ class irDataClient:
         }
         if club_id:
             payload["club_id"] = club_id
-        if division:
+        if division is not None:
             payload["division"] = division
 
         resource = self._get_resource("/data/stats/season_tt_results", payload=payload)
@@ -1218,7 +1218,7 @@ class irDataClient:
         Args:
             season_id (int): The iRacing season id.
             car_class_id (int): the iRacing car class id.
-            race_week_num (int): the race week number (0-12). Default 0.
+            race_week_num (int): the race week number (0-12).
             club_id (int): the iRacing club id.
             division (int): the iRacing division.
 
@@ -1233,7 +1233,7 @@ class irDataClient:
         }
         if club_id:
             payload["club_id"] = club_id
-        if division:
+        if division is not None:
             payload["division"] = division
 
         resource = self._get_resource(

--- a/tests.py
+++ b/tests.py
@@ -1162,6 +1162,14 @@ class TestIrDataClient(unittest.TestCase):
         )
         self.assertEqual(result, mock_get_resource.return_value)
 
+        self.client.result_season_results(
+            season_id, event_type=event_type, race_week_num=0
+        )
+        expected_payload["race_week_num"] = 0
+        mock_get_resource.assert_called_with(
+            "/data/results/season_results", payload=expected_payload
+        )
+
     @patch.object(irDataClient, "_get_resource")
     @patch.object(irDataClient, "_get_resource_or_link")
     def test_member_awards(self, mock_get_resource_or_link, mock_get_resource):
@@ -1307,6 +1315,20 @@ class TestIrDataClient(unittest.TestCase):
         mock_get_chunks.assert_called_once()
         self.assertEqual(result, mock_get_chunks.return_value)
 
+        # test for 0 inputs which used to remove the input
+        self.client.stats_season_driver_standings(
+            season_id=season_id, car_class_id=car_class_id, race_week_num=0, division=0
+        )
+        mock_get_resource.assert_called_with(
+            "/data/stats/season_driver_standings",
+            payload={
+                "season_id": season_id,
+                "car_class_id": car_class_id,
+                "race_week_num": 0,
+                "division": 0,
+            },
+        )
+
     @patch.object(irDataClient, "_get_resource")
     @patch.object(irDataClient, "_get_chunks")
     def test_stats_season_supersession_standings(
@@ -1328,6 +1350,20 @@ class TestIrDataClient(unittest.TestCase):
         mock_get_chunks.assert_called_once()
         self.assertEqual(result, mock_get_chunks.return_value)
 
+        # test for 0 inputs which used to remove the input
+        self.client.stats_season_supersession_standings(
+            season_id=season_id, car_class_id=car_class_id, race_week_num=0, division=0
+        )
+        mock_get_resource.assert_called_with(
+            "/data/stats/season_supersession_standings",
+            payload={
+                "season_id": season_id,
+                "car_class_id": car_class_id,
+                "race_week_num": 0,
+                "division": 0,
+            },
+        )
+
     @patch.object(irDataClient, "_get_resource")
     @patch.object(irDataClient, "_get_chunks")
     def test_stats_season_team_standings(self, mock_get_chunks, mock_get_resource):
@@ -1345,6 +1381,19 @@ class TestIrDataClient(unittest.TestCase):
         mock_get_chunks.assert_called_once()
         self.assertEqual(result, mock_get_chunks.return_value)
 
+        self.client.stats_season_team_standings(
+            season_id, car_class_id, race_week_num=0
+        )
+
+        mock_get_resource.assert_called_with(
+            "/data/stats/season_team_standings",
+            payload={
+                "season_id": season_id,
+                "car_class_id": car_class_id,
+                "race_week_num": 0,
+            },
+        )
+
     @patch.object(irDataClient, "_get_resource")
     @patch.object(irDataClient, "_get_chunks")
     def test_stats_season_tt_standings(self, mock_get_chunks, mock_get_resource):
@@ -1361,6 +1410,20 @@ class TestIrDataClient(unittest.TestCase):
         )
         mock_get_chunks.assert_called_once()
         self.assertEqual(result, mock_get_chunks.return_value)
+
+        self.client.stats_season_tt_standings(
+            season_id, car_class_id, race_week_num=0, division=0
+        )
+
+        mock_get_resource.assert_called_with(
+            "/data/stats/season_tt_standings",
+            payload={
+                "season_id": season_id,
+                "car_class_id": car_class_id,
+                "race_week_num": 0,
+                "division": 0,
+            },
+        )
 
     @patch.object(irDataClient, "_get_resource")
     @patch.object(irDataClient, "_get_chunks")
@@ -1386,6 +1449,20 @@ class TestIrDataClient(unittest.TestCase):
         mock_get_chunks.assert_called_once()
         self.assertEqual(result, mock_get_chunks.return_value)
 
+        self.client.stats_season_tt_results(
+            season_id, car_class_id, race_week_num, division=0
+        )
+
+        mock_get_resource.assert_called_with(
+            "/data/stats/season_tt_results",
+            payload={
+                "season_id": season_id,
+                "car_class_id": car_class_id,
+                "race_week_num": race_week_num,
+                "division": 0,
+            },
+        )
+
     @patch.object(irDataClient, "_get_resource")
     @patch.object(irDataClient, "_get_chunks")
     def test_stats_season_qualify_results(self, mock_get_chunks, mock_get_resource):
@@ -1409,6 +1486,20 @@ class TestIrDataClient(unittest.TestCase):
         )
         mock_get_chunks.assert_called_once()
         self.assertEqual(result, mock_get_chunks.return_value)
+
+        self.client.stats_season_qualify_results(
+            season_id, car_class_id, race_week_num, division=0
+        )
+
+        mock_get_resource.assert_called_with(
+            "/data/stats/season_qualify_results",
+            payload={
+                "season_id": season_id,
+                "car_class_id": car_class_id,
+                "race_week_num": race_week_num,
+                "division": 0,
+            },
+        )
 
     @patch.object(irDataClient, "_get_chunks")
     @patch.object(irDataClient, "_get_resource")


### PR DESCRIPTION
Several functions use default values of None and then check for the presence of an argument with an if statement.  This works fine for values where 0 is not a valid argument but fails to work properly in those cases.  Where I ran into this was the following:

```python
def stats_season_driver_standings(
        self, season_id, car_class_id, race_week_num=None, club_id=None, division=None
    ):
```
which includes the line:
```python
        if race_week_num:
            payload["race_week_num"] = race_week_num
        if division:
            payload["division"] = division
```
The problem is that race_week_num = 0 and division = 0 are both valid but don't evaluate as True, so the payload doesn't get updated and the API responds incorrectly. 

To fix this, I modified the code to the following:

```python
        if race_week_num is not None:
            payload["race_week_num"] = race_week_num
        if division is not None:
            payload["division"] = division
```

I attempted to catch all the functions where this occurred but may have missed some.  For the most part, I think only division and race_week_num have this problem, since a value of 0 for other options is probably an error.

There were also a few doc strings that states that race_week_num defaults to 0, but it doesn't, so I deleted them.

