### PR TITLE
Remove cust_id/host_cust_id requirement from result_search_hosted

### DIFF
--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -762,9 +762,6 @@ class irDataClient:
                 "Please supply either start_range_begin or finish_range_begin"
             )
 
-        if not (cust_id or host_cust_id):
-            raise RuntimeError("Please supply either cust_id or host_cust_id")
-
         params = locals()
         payload = {}
         for x in params.keys():


### PR DESCRIPTION
iRacing is not requiring cust_id or host_cust_id and I can't find any reference to why it might be necessary. It works without and makes the search more flexible.

Jason, thanks for the tool! My first PR; guidance on best practices appreciated. :)