### PR TITLE
fix: include falsy but valid parameter values (e.g. 0, False) in payload

### DIFF
--- a/src/iracingdataapi/client.py
+++ b/src/iracingdataapi/client.py
@@ -800,9 +800,9 @@ class irDataClient:
 
         params = locals()
         payload = {}
-        for x in params.keys():
-            if x != "self" and params[x]:
-                payload[x] = params[x]
+        for x, val in params.items():
+            if x != "self" and val is not None:
+                payload[x] = val
 
         resource = self._get_resource("/data/results/search_hosted", payload=payload)
         return self._get_chunks(resource.get("data", dict()).get("chunk_info"))
@@ -861,9 +861,9 @@ class irDataClient:
 
         params = locals()
         payload = {}
-        for x in params.keys():
-            if x != "self" and params[x]:
-                payload[x] = params[x]
+        for x, val in params.items():
+            if x != "self" and val is not None:
+                payload[x] = val
 
         resource = self._get_resource("/data/results/search_series", payload=payload)
         return self._get_chunks(resource.get("data", dict()).get("chunk_info"))


### PR DESCRIPTION
Previously, the payload builder filtered parameters using a truthiness check (`if params[x]:`). This unintentionally excluded valid values such as `race_week_num=0` or `official_only=False`.

Updated the logic to only exclude parameters that are explicitly `None`, ensuring falsy but valid values are preserved in the payload.  Added new test `test_result_search_series_with_race_week_num_0()` to verify fix.  

Fixes #48.